### PR TITLE
fix build for fedora 20

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,5 +9,5 @@ set(executables test-base test-trans test-generators test-partition test-permuta
 foreach(_exec ${executables})
   add_executable (${_exec} "${_exec}.cpp")
   add_test(${_exec} ${_exec})
-  target_link_libraries(${_exec} boost_unit_test_framework-mt)
+  target_link_libraries(${_exec} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 endforeach(_exec)


### PR DESCRIPTION
The *-mt libraries seem to have been dropped on fedora, since everything is built in multi-threaded mode now. By using the cmake variable instead of the library name, cmake takes care of this.

see https://lists.fedoraproject.org/pipermail/scm-commits/Week-of-Mon-20130624/1047486.html
